### PR TITLE
Added eigen_catkin_enforce macro.

### DIFF
--- a/cmake/eigen-extras.cmake.in
+++ b/cmake/eigen-extras.cmake.in
@@ -1,1 +1,13 @@
 set(@PROJECT_NAME@_INCLUDE_DIRS @CATKIN_DEVEL_PREFIX@/include/eigen3/)
+
+# The following eigen_catkin_enforce macro can be called in a depending 
+# project's CMakeLists.txt file (Below findpackage eigen_catkin or the 
+# catkin_simple() call.
+# It will ensure that eigen_catkin's lib Eigen will be included instead 
+# of any other possible candidate (like a system installation of Eigen).
+#
+# It is possible to get that right by careful treatment of workspace layer 
+# order but calling this macro is easier.
+macro(eigen_catkin_enforce)
+	include_directories(BEFORE ${@PROJECT_NAME@_INCLUDE_DIRS})
+endmacro()


### PR DESCRIPTION
It can be called in a depender project's CMakeLists.txt file (below findpackage eigen_catkin or the catkin_simple() call) to ensure eigen_catkin's lib Eigen will be included instead of any other possible candidate (like a system installation of Eigen).
It is possible to get that right by careful treatment of workspace layer order but calling this macro is easier.

@simonlynen : The former plan of letting this done automatically by the eigen-extras.cmake.in is impossible :(, as catkin is reordering include files after all extras are run! It will enforce a so called "workspace order". And this can only be influenced by the order of workspace layers and people have troubles keeping this order clean.

I will pull this in to the gtsam_eigen branch. We won't need it in master but it would also not hurt. Maybe there are other use cases for this?
