### PR TITLE
Update to 3.2.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(ExternalProject)
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/eigen3)
 
 ExternalProject_Add(eigen_src
-  URL https://github.com/ethz-asl/thirdparty_library_binaries/raw/master/Eigen_3.2.7.tar.gz
+  URL http://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2
   UPDATE_COMMAND ""
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}  -DCMAKE_BUILD_TYPE:STRING=Release
 )


### PR DESCRIPTION
3.2.10 fixes the warnings when compiling against C++11 (see http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1276), which is default in Ubuntu 16.04.

@dymczykm Is there a reason why we have Eigen in our own repository?