### PR TITLE
switched to latest eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ else()
   file(MAKE_DIRECTORY ${EIGEN_CATKIN_EIGEN_INCLUDE})
   ExternalProject_Add(eigen_src
     UPDATE_COMMAND ""
-    URL http://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2
+    URL http://bitbucket.org/eigen/eigen/get/3.3.3.tar.bz2
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}  -DCMAKE_BUILD_TYPE:STRING=Release
   )
 


### PR DESCRIPTION
Recently we have been hitting some issues with Eigen complaining about partial specializations of std::vector.

The issue appears when using eigen_catkin on ubuntu 14.04 when including a file that does not use StdVector.h and has a std::vector of eigen types before one that does. This means that reordering the header files included can make this error appear or disappear, which is why it is showing up in seemingly unrelated pull requests.

The latest version of eigen solves this issue. 