### PR TITLE
Fix path to StdVector.patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ else()
   ExternalProject_Add(eigen_src
     UPDATE_COMMAND ""
     URL http://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2
-    PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/StdVector.patch
+    PATCH_COMMAND patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/StdVector.patch
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}  -DCMAKE_BUILD_TYPE:STRING=Release
   )
 


### PR DESCRIPTION
`eigen_catkin` seems to fail when building a Eigen as an external project. This patch points CMake to the correct location for `StdVector.patch`

```
$ catkin_make --pkg eigen_catkin
...
-- extracting... [tar xfz]
-- extracting... [analysis]
-- extracting... [rename]
-- extracting... [clean up]
-- extracting... done
[ 40%] No update step for 'eigen_src'
[ 40%] Performing patch step for 'eigen_src'
/bin/sh: 1: cannot open /tmp/f/foo_ws/src/StdVector.patch: No such file
eigen_catkin/CMakeFiles/eigen_src.dir/build.make:101: recipe for target 'eigen_catkin/eigen_src-prefix/src/eigen_src-stamp/eigen_src-patch' failed
make[2]: *** [eigen_catkin/eigen_src-prefix/src/eigen_src-stamp/eigen_src-patch] Error 2
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:413: recipe for target 'eigen_catkin/CMakeFiles/eigen_src.dir/all' failed
make[1]: *** [eigen_catkin/CMakeFiles/eigen_src.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
Invoking "make -j4 -l4" failed
```