### PR TITLE
Upgrade to 3.3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,9 @@ else()
   ExternalProject_Add(eigen_src
     UPDATE_COMMAND ""
     URL http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
-    PATCH_COMMAND patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/StdVector.patch
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}  -DCMAKE_BUILD_TYPE:STRING=Release
+    URL_MD5 a7aab9f758249b86c93221ad417fbe18
+    PATCH_COMMAND patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/StdVector.patch && patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/DisableTests.patch && patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/FixWarning.patch
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX} -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_TESTING=OFF
   )
 
   if(EXISTS ${EIGEN_CATKIN_EIGEN_INCLUDE_SIGNATURE}.off)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ else()
   file(MAKE_DIRECTORY ${EIGEN_CATKIN_EIGEN_INCLUDE})
   ExternalProject_Add(eigen_src
     UPDATE_COMMAND ""
-    URL http://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2
+    URL http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
     PATCH_COMMAND patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/StdVector.patch
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}  -DCMAKE_BUILD_TYPE:STRING=Release
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(ExternalProject)
 set(EIGEN_CATKIN_EIGEN_INCLUDE ${CATKIN_DEVEL_PREFIX}/include/eigen3)
 set(EIGEN_CATKIN_EIGEN_INCLUDE_SIGNATURE ${EIGEN_CATKIN_EIGEN_INCLUDE}/signature_of_eigen3_matrix_library)
 
-set(EIGEN_MINIMUM_VERSION 3.2.10)
+set(EIGEN_MINIMUM_VERSION 3.3.4)
 
 # If set to OFF, will compile the given version of Eigen.
 # If set to ON, will use the system version of Eigen.

--- a/DisableTests.patch
+++ b/DisableTests.patch
@@ -1,0 +1,77 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -416,16 +416,15 @@ add_subdirectory(Eigen)
+
+ add_subdirectory(doc EXCLUDE_FROM_ALL)
+
+-include(EigenConfigureTesting)
++option(BUILD_TESTING "Enable creation of Eigen tests." ON)
++if(BUILD_TESTING)
++  include(EigenConfigureTesting)
+
+-# fixme, not sure this line is still needed:
+-enable_testing() # must be called from the root CMakeLists, see man page
+-
+-
+-if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+-  add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
+-else()
+-  add_subdirectory(test EXCLUDE_FROM_ALL)
++  if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
++    add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
++  else()
++    add_subdirectory(test EXCLUDE_FROM_ALL)
++  endif()
+ endif()
+
+ if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+@@ -461,7 +460,9 @@ endif(NOT WIN32)
+
+ configure_file(scripts/cdashtesting.cmake.in cdashtesting.cmake @ONLY)
+
+-ei_testing_print_summary()
++if(BUILD_TESTING)
++  ei_testing_print_summary()
++endif()
+
+ message(STATUS "")
+ message(STATUS "Configured Eigen ${EIGEN_VERSION_NUMBER}")
+diff --git a/blas/CMakeLists.txt b/blas/CMakeLists.txt
+index d0efb4188..9887d5804 100644
+--- blas/CMakeLists.txt
++++ blas/CMakeLists.txt
+@@ -45,10 +45,12 @@ install(TARGETS eigen_blas eigen_blas_static
+
+ if(EIGEN_Fortran_COMPILER_WORKS)
+
+-if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+-  add_subdirectory(testing) # can't do EXCLUDE_FROM_ALL here, breaks CTest
+-else()
+-  add_subdirectory(testing EXCLUDE_FROM_ALL)
++if(BUILD_TESTING)
++  if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
++    add_subdirectory(testing) # can't do EXCLUDE_FROM_ALL here, breaks CTest
++  else()
++    add_subdirectory(testing EXCLUDE_FROM_ALL)
++  endif()
+ endif()
+
+ endif()
+diff --git a/unsupported/CMakeLists.txt b/unsupported/CMakeLists.txt
+index 4fef40a86..9a5666105 100644
+--- unsupported/CMakeLists.txt
++++ unsupported/CMakeLists.txt
+@@ -1,7 +1,9 @@
+ add_subdirectory(Eigen)
+ add_subdirectory(doc EXCLUDE_FROM_ALL)
+-if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+-  add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
+-else()
+-  add_subdirectory(test EXCLUDE_FROM_ALL)
++if(BUILD_TESTING)
++  if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
++    add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
++  else()
++    add_subdirectory(test EXCLUDE_FROM_ALL)
++  endif()
+ endif()

--- a/FixWarning.patch
+++ b/FixWarning.patch
@@ -1,0 +1,40 @@
+--- Eigen/src/Core/AssignEvaluator.h	2019-12-25 13:19:30.927689094 +0100
++++ Eigen/src/Core/AssignEvaluator.h	2019-12-25 13:19:32.779688334 +0100
+@@ -83,11 +83,11 @@
+                        && int(OuterStride)!=Dynamic && int(OuterStride)%int(InnerPacketSize)==0
+                        && (EIGEN_UNALIGNED_VECTORIZE  || int(JointAlignment)>=int(InnerRequiredAlignment)),
+     MayLinearize = bool(StorageOrdersAgree) && (int(DstFlags) & int(SrcFlags) & LinearAccessBit),
+-    MayLinearVectorize = bool(MightVectorize) && MayLinearize && DstHasDirectAccess
++    MayLinearVectorize = bool(MightVectorize) && MayLinearize && (DstHasDirectAccess!=0)
+                        && (EIGEN_UNALIGNED_VECTORIZE || (int(DstAlignment)>=int(LinearRequiredAlignment)) || MaxSizeAtCompileTime == Dynamic),
+       /* If the destination isn't aligned, we have to do runtime checks and we don't unroll,
+          so it's only good for large enough sizes. */
+-    MaySliceVectorize  = bool(MightVectorize) && bool(DstHasDirectAccess)
++    MaySliceVectorize  = bool(MightVectorize) && (DstHasDirectAccess!=0)
+                        && (int(InnerMaxSize)==Dynamic || int(InnerMaxSize)>=(EIGEN_UNALIGNED_VECTORIZE?InnerPacketSize:(3*InnerPacketSize)))
+       /* slice vectorization can be slow, so we only want it if the slices are big, which is
+          indicated by InnerMaxSize rather than InnerSize, think of the case of a dynamic block
+--- Eigen/src/Core/products/GeneralMatrixVector.h	2017-06-15 09:10:20.000000000 +0200
++++ Eigen/src/Core/products/GeneralMatrixVector.h	2019-12-25 13:59:41.286547822 +0100
+@@ -183,8 +183,8 @@
+     alignmentPattern = AllAligned;
+   }
+
+-  const Index offset1 = (FirstAligned && alignmentStep==1)?3:1;
+-  const Index offset3 = (FirstAligned && alignmentStep==1)?1:3;
++  const Index offset1 = (FirstAligned!=0 && alignmentStep==1)?3:1;
++  const Index offset3 = (FirstAligned!=0 && alignmentStep==1)?1:3;
+
+   Index columnBound = ((cols-skipColumns)/columnsAtOnce)*columnsAtOnce + skipColumns;
+   for (Index i=skipColumns; i<columnBound; i+=columnsAtOnce)
+@@ -457,8 +457,8 @@
+     alignmentPattern = AllAligned;
+   }
+
+-  const Index offset1 = (FirstAligned && alignmentStep==1)?3:1;
+-  const Index offset3 = (FirstAligned && alignmentStep==1)?1:3;
++  const Index offset1 = (FirstAligned!=0 && alignmentStep==1)?3:1;
++  const Index offset3 = (FirstAligned!=0 && alignmentStep==1)?1:3;
+
+   Index rowBound = ((rows-skipRows)/rowsAtOnce)*rowsAtOnce + skipRows;
+   for (Index i=skipRows; i<rowBound; i+=rowsAtOnce)

--- a/StdVector.patch
+++ b/StdVector.patch
@@ -3,16 +3,16 @@
 @@ -14,6 +14,8 @@
  #include "Core"
  #include <vector>
- 
+
 +#if __cplusplus < 201103L
 +
- #if (defined(_MSC_VER) && defined(_WIN64)) /* MSVC auto aligns in 64 bit builds */
- 
+ #if EIGEN_COMP_MSVC && EIGEN_OS_WIN64 && (EIGEN_MAX_STATIC_ALIGN_BYTES<=16) /* MSVC auto aligns up to 16 bytes in 64 bit builds */
+
  #define EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(...)
 @@ -24,4 +26,6 @@
- 
+
  #endif
- 
+
 +#endif
 +
  #endif // EIGEN_STDVECTOR_MODULE_H


### PR DESCRIPTION
With this upgrade, the version is the same on 14.04 (from source), 16.04 (from source) and 18.04 (system)

The two patches were required to:
 - Disable the tests that require a fortran compiler to be present, [patch source](https://gitlab.kitware.com/phcerdan/eigen/commit/b2bcf83cb0d7a39bc1a86594299d6584361edf1c). There should be a better way to do this though...
 - Fix compiler warnings